### PR TITLE
Support private IAM endpoints

### DIFF
--- a/hpcs-for-luks/dracut/95hpcs-for-luks/hpcs-for-luks-dracut.sh
+++ b/hpcs-for-luks/dracut/95hpcs-for-luks/hpcs-for-luks-dracut.sh
@@ -21,13 +21,16 @@ parse_ini() {
 			default_crk_uuid*)
 				_DEFAULT_CRK_UUID=`echo ${INI_LINE##*=}`
 				;;
+			iam_endpoint_url*)
+				_IAM_ENDPOINT_URL=`echo ${INI_LINE##*=}`
+				;;
 		esac
 	done < /etc/${_UTILITY_NAME}.ini
 }
 
 authenticate() {
 	_AUTH_JSON=`curl -X POST \
-	"https://iam.cloud.ibm.com/identity/token" \
+	"$_IAM_ENDPOINT_URL/identity/token" \
 	--header 'Content-Type: application/x-www-form-urlencoded' \
 	--header 'Accept: application/json' \
 	--data-urlencode 'grant_type=urn:ibm:params:oauth:grant-type:apikey' \

--- a/hpcs-for-luks/hpcs-for-luks
+++ b/hpcs-for-luks/hpcs-for-luks
@@ -70,6 +70,15 @@ def parse_config(config_file):
     except:
         config['KP']['default_crk_uuid'] = ''
 
+    # If optonal iam_endpoint_url isn't set, set it to the default public URL
+
+    try:
+        if config['KP']['iam_endpoint_url'] == None:
+            pass
+    except:
+        config['KP']['iam_endpoint_url'] = 'https://iam.cloud.ibm.com'
+
+
     # Check the optional HFL section exists; if not, set it to the None object.
 
     try:
@@ -185,9 +194,9 @@ def tpm_unseal(config):
 #  Initialize key protect
 #
 
-def init_keyprotect(api_key, region, service_instance_id, endpoint_url):
+def init_keyprotect(api_key, region, service_instance_id, endpoint_url, iam_endpoint):
 
-    tm = keyprotect.bxauth.TokenManager(api_key=api_key)
+    tm = keyprotect.bxauth.TokenManager(api_key=api_key, iam_endpoint=iam_endpoint)
     kp = keyprotect.Client(credentials=tm,
                            region=region,
                            service_instance_id=service_instance_id,
@@ -457,7 +466,8 @@ tpm_unseal(config)
 kp = init_keyprotect(config['KP']['api_key'],
                      config['KP']['region'],
                      config['KP']['service_instance_id'],
-                     config['KP']['endpoint_url'])
+                     config['KP']['endpoint_url'],
+                     config['KP']['iam_endpoint_url'])
 
 # Instantiate key_protect_luks object
 

--- a/hpcs-for-luks/hpcs-for-luks.ini
+++ b/hpcs-for-luks/hpcs-for-luks.ini
@@ -4,3 +4,4 @@ endpoint_url =
 service_instance_id = 
 api_key = 
 default_crk_uuid = 
+iam_endpoint_url =


### PR DESCRIPTION
Add support for private IAM endpoints.

I keeping this as a draft since it requires the redstone pip package to also support private IAM endpoints. A PR is open for that fix: https://github.com/IBM/redstone/issues/23

This code is also minimally tested for create root key wrap and unwrap using "https://private.iam.cloud.com" as a private endpoint. The `dracut` paths are untested.

The PR is also incomplete in that the documentation should be updated to call out the new redstone package requirement and the new .ini config field.

Fixes: #5 